### PR TITLE
Support anytypes and advanced primitives

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -61,7 +61,7 @@ public class CodegenModel {
     public Set<String> allMandatory = new TreeSet<String>(); // with parent's required properties
 
     public Set<String> imports = new TreeSet<String>();
-    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel, isFreeFormObject, isAnyTypeModel;
+    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel, isFreeFormObject, isAnyTypeModel, isPrimitiveType;
     public boolean hasOnlyReadOnly = true; // true if all properties are read-only
     public ExternalDocumentation externalDocumentation;
 
@@ -120,6 +120,7 @@ public class CodegenModel {
                 .append("isMapModel", isMapModel)
                 .append("isFreeFormObject", isFreeFormObject)
                 .append("isAnyTypeModel", isAnyTypeModel)
+                .append("isPrimitiveType", isPrimitiveType)
                 .append("hasOnlyReadOnly", hasOnlyReadOnly)
                 .append("externalDocumentation", externalDocumentation)
                 .append("vendorExtensions", vendorExtensions)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -61,7 +61,7 @@ public class CodegenModel {
     public Set<String> allMandatory = new TreeSet<String>(); // with parent's required properties
 
     public Set<String> imports = new TreeSet<String>();
-    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel;
+    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel, isFreeFormObject, isAnyTypeModel;
     public boolean hasOnlyReadOnly = true; // true if all properties are read-only
     public ExternalDocumentation externalDocumentation;
 
@@ -118,6 +118,8 @@ public class CodegenModel {
                 .append("isArrayModel", isArrayModel)
                 .append("hasChildren", hasChildren)
                 .append("isMapModel", isMapModel)
+                .append("isFreeFormObject", isFreeFormObject)
+                .append("isAnyTypeModel", isAnyTypeModel)
                 .append("hasOnlyReadOnly", hasOnlyReadOnly)
                 .append("externalDocumentation", externalDocumentation)
                 .append("vendorExtensions", vendorExtensions)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -55,7 +55,7 @@ public class CodegenProperty implements Cloneable {
     public boolean hasMoreNonReadOnly; // for model constructor, true if next property is not readonly
     public boolean isPrimitiveType, isModel, isContainer;
     public boolean isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isFile,
-            isBoolean, isDate, isDateTime, isUuid, isEmail, isFreeFormObject;
+            isBoolean, isDate, isDateTime, isUuid, isEmail, isFreeFormObject, isAnyType;
     public boolean isListContainer, isMapContainer;
     public boolean isEnum;
     public boolean isReadOnly;
@@ -474,6 +474,7 @@ public class CodegenProperty implements Cloneable {
             isUuid,
             isEmail,
             isFreeFormObject,
+            isAnyType,
             isMapContainer,
             isListContainer,
             isInherited,
@@ -554,6 +555,7 @@ public class CodegenProperty implements Cloneable {
             Objects.equals(isUuid, other.isUuid) &&
             Objects.equals(isEmail, other.isEmail) &&
             Objects.equals(isFreeFormObject, other.isFreeFormObject) &&
+            Objects.equals(isAnyType, other.isAnyType) &&
             Objects.equals(isBinary, other.isBinary) &&
             Objects.equals(isFile, other.isFile) &&
             Objects.equals(isListContainer, other.isListContainer) &&
@@ -651,6 +653,7 @@ public class CodegenProperty implements Cloneable {
                 ", isUuid=" + isUuid +
                 ", isEmail=" + isEmail +
                 ", isFreeFormObject=" + isFreeFormObject +
+                ", isAnyType=" + isAnyType +
                 ", isListContainer=" + isListContainer +
                 ", isMapContainer=" + isMapContainer +
                 ", isEnum=" + isEnum +

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1757,6 +1757,10 @@ public class DefaultCodegen implements CodegenConfig {
             if (ModelUtils.isMapSchema(schema)) {
                 addAdditionPropertiesToCodeGenModel(m, schema);
                 m.isMapModel = Boolean.TRUE;
+                // Maps with no properties are aliases to simple types
+                if (schema.getProperties() == null || schema.getProperties().isEmpty()) {
+                    m.isAlias = Boolean.TRUE;
+                }
             }
             if (ModelUtils.isIntegerSchema(schema)) { // integer type
                 if (!ModelUtils.isLongSchema(schema)) { // long type is not integer
@@ -2030,6 +2034,8 @@ public class DefaultCodegen implements CodegenConfig {
 
         } else if (ModelUtils.isFreeFormObject(p)) {
             property.isFreeFormObject = true;
+        } else if (ModelUtils.isAnyType(p)) {
+            property.isAnyType = true;
         }
 
         //Inline enum case:

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1757,26 +1757,28 @@ public class DefaultCodegen implements CodegenConfig {
             if (ModelUtils.isMapSchema(schema)) {
                 addAdditionPropertiesToCodeGenModel(m, schema);
                 m.isMapModel = Boolean.TRUE;
-                // Maps with no properties are aliases to simple types
+                // Maps with no properties are primitive types
                 if (schema.getProperties() == null || schema.getProperties().isEmpty()) {
-                    m.isAlias = Boolean.TRUE;
+                    m.isPrimitiveType = Boolean.TRUE;
                 }
             }
             if (ModelUtils.isIntegerSchema(schema)) { // integer type
                 if (!ModelUtils.isLongSchema(schema)) { // long type is not integer
                     m.isInteger = Boolean.TRUE;
                 }
+                m.isPrimitiveType = Boolean.TRUE;
             }
             if (ModelUtils.isStringSchema(schema)) {
                 m.isString = Boolean.TRUE;
+                m.isPrimitiveType = Boolean.TRUE;
             }
             if (ModelUtils.isFreeFormObject(schema)) {
                 m.isFreeFormObject = Boolean.TRUE;
-                m.isAlias = Boolean.TRUE;
+                m.isPrimitiveType = Boolean.TRUE;
             }
             if (ModelUtils.isAnyType(schema)) {
                 m.isAnyTypeModel = Boolean.TRUE;
-                m.isAlias = Boolean.TRUE;
+                m.isPrimitiveType = Boolean.TRUE;
             }
 
             // passing null to allProperties and allRequired as there's no parent

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1756,7 +1756,7 @@ public class DefaultCodegen implements CodegenConfig {
             }
             if (ModelUtils.isMapSchema(schema)) {
                 addAdditionPropertiesToCodeGenModel(m, schema);
-                m.isMapModel = true;
+                m.isMapModel = Boolean.TRUE;
             }
             if (ModelUtils.isIntegerSchema(schema)) { // integer type
                 if (!ModelUtils.isLongSchema(schema)) { // long type is not integer
@@ -1765,6 +1765,14 @@ public class DefaultCodegen implements CodegenConfig {
             }
             if (ModelUtils.isStringSchema(schema)) {
                 m.isString = Boolean.TRUE;
+            }
+            if (ModelUtils.isFreeFormObject(schema)) {
+                m.isFreeFormObject = Boolean.TRUE;
+                m.isAlias = Boolean.TRUE;
+            }
+            if (ModelUtils.isAnyType(schema)) {
+                m.isAnyTypeModel = Boolean.TRUE;
+                m.isAlias = Boolean.TRUE;
             }
 
             // passing null to allProperties and allRequired as there's no parent

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -488,7 +488,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 // Special handling of aliases only applies to Java
                 if (modelTemplate != null && modelTemplate.containsKey("model")) {
                     CodegenModel m = (CodegenModel) modelTemplate.get("model");
-                    if (m.isAlias && !ModelUtils.isGenerateAliasAsModel()) {
+                    if (m.isAlias) {
                         continue;  // Don't create user-defined classes for aliases
                     }
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -430,7 +430,19 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
                 Schema schema = schemas.get(name);
 
-                if (ModelUtils.isMapSchema(schema)) { // check to see if it's a "map" model
+                if (ModelUtils.isAnyType(schema)) { // check to see if it's an any-type schema
+                    if (!ModelUtils.isGenerateAliasAsModel()) {
+                        // schema without property, i.e. alias to map
+                        LOGGER.info("Model " + name + " not generated since it's an alias to any type and `generateAliasAsModel` is set to false (default)");
+                        continue;
+                    }
+                } else if (ModelUtils.isFreeFormObject(schema)) { // check to see if it's a free-form object
+                    if (!ModelUtils.isGenerateAliasAsModel()) {
+                        // schema without property, i.e. alias to map
+                        LOGGER.info("Model " + name + " not generated since it's an alias to a free-form object and `generateAliasAsModel` is set to false (default)");
+                        continue;
+                    }
+                } else if (ModelUtils.isMapSchema(schema)) { // check to see if it's a "map" model
                     if (!ModelUtils.isGenerateAliasAsModel() && (schema.getProperties() == null || schema.getProperties().isEmpty())) {
                         // schema without property, i.e. alias to map
                         LOGGER.info("Model " + name + " not generated since it's an alias to map (without property) and `generateAliasAsModel` is set to false (default)");
@@ -476,7 +488,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 // Special handling of aliases only applies to Java
                 if (modelTemplate != null && modelTemplate.containsKey("model")) {
                     CodegenModel m = (CodegenModel) modelTemplate.get("model");
-                    if (m.isAlias) {
+                    if (m.isAlias && !ModelUtils.isGenerateAliasAsModel()) {
                         continue;  // Don't create user-defined classes for aliases
                     }
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -86,9 +86,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         );
 
         instantiationTypes.clear();
-        /*instantiationTypes.put("array", "GoArray");
-        instantiationTypes.put("map", "GoMap");*/
-
+        
         typeMapping.clear();
         typeMapping.put("integer", "int32");
         typeMapping.put("long", "int64");
@@ -266,13 +264,22 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         if (ModelUtils.isArraySchema(p)) {
             ArraySchema ap = (ArraySchema) p;
             Schema inner = ap.getItems();
+            if (ModelUtils.isAnyType(inner)) {
+                return "[]interface{}";
+            }
             return "[]" + getTypeDeclaration(inner);
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
+            if (ModelUtils.isAnyType(inner)) {
+                return "map[string]interface{}";
+            }
             return getSchemaType(p) + "[string]" + getTypeDeclaration(inner);
+        } else if (ModelUtils.isFreeFormObject(p)) {
+            return "map[string]interface{}";
+        } else if (ModelUtils.isAnyType(p)) {
+            return "interface{}";
         }
-        //return super.getTypeDeclaration(p);
-
+        
         // Not using the supertype invocation, because we want to UpperCamelize
         // the type.
         String openAPIType = getSchemaType(p);
@@ -308,7 +315,29 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
         if (ref != null && !ref.isEmpty()) {
             type = openAPIType;
-        } else if (typeMapping.containsKey(openAPIType)) {
+        }
+        else if (ModelUtils.isArraySchema(p)) {
+            ArraySchema ap = (ArraySchema) p;
+            Schema inner = ap.getItems();
+            if (ModelUtils.isAnyType(inner)) {
+                return "[]interface{}";
+            }
+            return "[]" + getTypeDeclaration(inner);
+        }
+        // else if (ModelUtils.isMapSchema(p)) {
+        //     Schema inner = ModelUtils.getAdditionalProperties(p);
+        //     if (ModelUtils.isAnyType(inner)) {
+        //         return "map[string]interface{}";
+        //     }
+        //     return getSchemaType(p) + "[string]" + getTypeDeclaration(inner);
+        // }
+        else if (ModelUtils.isFreeFormObject(p)) {
+            return "map[string]interface{}";
+        }
+        else if (ModelUtils.isAnyType(p)) {
+            return "interface{}";
+        }
+        else if (typeMapping.containsKey(openAPIType)) {
             type = typeMapping.get(openAPIType);
             if (languageSpecificPrimitives.contains(type))
                 return (type);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -273,7 +273,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             if (ModelUtils.isAnyType(inner)) {
                 return "map[string]interface{}";
             }
-            return getSchemaType(p) + "[string]" + getTypeDeclaration(inner);
+            return "map[string]" + getTypeDeclaration(inner);
         } else if (ModelUtils.isFreeFormObject(p)) {
             return "map[string]interface{}";
         } else if (ModelUtils.isAnyType(p)) {
@@ -315,29 +315,24 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
         if (ref != null && !ref.isEmpty()) {
             type = openAPIType;
-        }
-        else if (ModelUtils.isArraySchema(p)) {
+        } else if (ModelUtils.isArraySchema(p)) {
             ArraySchema ap = (ArraySchema) p;
             Schema inner = ap.getItems();
             if (ModelUtils.isAnyType(inner)) {
                 return "[]interface{}";
             }
             return "[]" + getTypeDeclaration(inner);
-        }
-        // else if (ModelUtils.isMapSchema(p)) {
-        //     Schema inner = ModelUtils.getAdditionalProperties(p);
-        //     if (ModelUtils.isAnyType(inner)) {
-        //         return "map[string]interface{}";
-        //     }
-        //     return getSchemaType(p) + "[string]" + getTypeDeclaration(inner);
-        // }
-        else if (ModelUtils.isFreeFormObject(p)) {
+        } else if (ModelUtils.isFreeFormObject(p)) {
             return "map[string]interface{}";
-        }
-        else if (ModelUtils.isAnyType(p)) {
+        } else if (ModelUtils.isAnyType(p)) {
             return "interface{}";
-        }
-        else if (typeMapping.containsKey(openAPIType)) {
+        } else if (ModelUtils.isMapSchema(p)) {
+            Schema inner = ModelUtils.getAdditionalProperties(p);
+            if (ModelUtils.isAnyType(inner)) {
+               return "map[string]interface{}";
+            }
+            return "map[string]" + getTypeDeclaration(inner);
+        } else if (typeMapping.containsKey(openAPIType)) {
             type = typeMapping.get(openAPIType);
             if (languageSpecificPrimitives.contains(type))
                 return (type);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -265,6 +265,10 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             ArraySchema ap = (ArraySchema) p;
             Schema inner = ap.getItems();
             return getSchemaType(p) + "<" + getTypeDeclaration(inner) + ">";
+        } else if (ModelUtils.isAnyType(p)) {
+            return "any";
+        } else if (ModelUtils.isFreeFormObject(p)) {
+            return "{ [key: string]: any; }";
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
             return "{ [key: string]: " + getTypeDeclaration(inner) + "; }";
@@ -395,7 +399,11 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     public String getSchemaType(Schema p) {
         String openAPIType = super.getSchemaType(p);
         String type = null;
-        if (typeMapping.containsKey(openAPIType)) {
+        if (ModelUtils.isAnyType(p)) {
+            return "any";
+        } else if (ModelUtils.isFreeFormObject(p)) {
+            return "[key: string]: any";
+        } else if (typeMapping.containsKey(openAPIType)) {
             type = typeMapping.get(openAPIType);
             if (languageSpecificPrimitives.contains(type))
                 return type;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -265,10 +265,6 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             ArraySchema ap = (ArraySchema) p;
             Schema inner = ap.getItems();
             return getSchemaType(p) + "<" + getTypeDeclaration(inner) + ">";
-        } else if (ModelUtils.isAnyType(p)) {
-            return "any";
-        } else if (ModelUtils.isFreeFormObject(p)) {
-            return "{ [key: string]: any; }";
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
             return "{ [key: string]: " + getTypeDeclaration(inner) + "; }";
@@ -399,11 +395,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     public String getSchemaType(Schema p) {
         String openAPIType = super.getSchemaType(p);
         String type = null;
-        if (ModelUtils.isAnyType(p)) {
-            return "any";
-        } else if (ModelUtils.isFreeFormObject(p)) {
-            return "[key: string]: any";
-        } else if (typeMapping.containsKey(openAPIType)) {
+        if (typeMapping.containsKey(openAPIType)) {
             type = typeMapping.get(openAPIType);
             if (languageSpecificPrimitives.contains(type))
                 return type;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -121,6 +121,10 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         if (ModelUtils.isArraySchema(p)) {
             inner = ((ArraySchema) p).getItems();
             return this.getSchemaType(p) + "<" + this.getTypeDeclaration(inner) + ">";
+        } else if (ModelUtils.isAnyType(p)) {
+            return "any";
+        } else if (ModelUtils.isFreeFormObject(p)) {
+            return "{ [key: string]: any; }";
         } else if (ModelUtils.isMapSchema(p)) {
             inner = ModelUtils.getAdditionalProperties(p);
             return "{ [key: string]: " + this.getTypeDeclaration(inner) + "; }";
@@ -134,6 +138,16 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             return "Date";
         }
         return super.getTypeDeclaration(p);
+    }
+
+    @Override
+    public String getSchemaType(Schema p) {
+        if (ModelUtils.isAnyType(p)) {
+            return "any";
+        } else if (ModelUtils.isFreeFormObject(p)) {
+            return "[key: string]: any";
+        }
+        return super.getSchemaType(p);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -118,16 +118,32 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     @Override
     public String getTypeDeclaration(Schema p) {
         Schema inner;
+        if ( ModelUtils.isArraySchema(p) ||
+             ModelUtils.isFileSchema(p) ||
+             ModelUtils.isBinarySchema(p) ||
+             ModelUtils.isDateSchema(p) ||
+             ModelUtils.isDateTimeSchema(p) ||
+             ModelUtils.isAnyType(p) ) {
+            return this.getSchemaType(p);
+        } else if (ModelUtils.isFreeFormObject(p) || ModelUtils.isMapSchema(p)) {
+            return "{ " + this.getSchemaType(p) + "; }";
+        }
+        return super.getTypeDeclaration(p);
+    }
+
+    @Override
+    public String getSchemaType(Schema p) {
+        Schema inner;
         if (ModelUtils.isArraySchema(p)) {
             inner = ((ArraySchema) p).getItems();
-            return this.getSchemaType(p) + "<" + this.getTypeDeclaration(inner) + ">";
+            return "Array<" + this.getTypeDeclaration(inner) + ">";
         } else if (ModelUtils.isAnyType(p)) {
             return "any";
         } else if (ModelUtils.isFreeFormObject(p)) {
-            return "{ [key: string]: any; }";
+            return "[key: string]: any";
         } else if (ModelUtils.isMapSchema(p)) {
             inner = ModelUtils.getAdditionalProperties(p);
-            return "{ [key: string]: " + this.getTypeDeclaration(inner) + "; }";
+            return "[key: string]: " + this.getTypeDeclaration(inner);
         } else if (ModelUtils.isFileSchema(p)) {
             return "Blob";
         } else if (ModelUtils.isBinarySchema(p)) {
@@ -137,23 +153,29 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         } else if (ModelUtils.isDateTimeSchema(p)) {
             return "Date";
         }
-        return super.getTypeDeclaration(p);
-    }
-
-    @Override
-    public String getSchemaType(Schema p) {
-        if (ModelUtils.isAnyType(p)) {
-            return "any";
-        } else if (ModelUtils.isFreeFormObject(p)) {
-            return "[key: string]: any";
-        }
         return super.getSchemaType(p);
     }
 
     @Override
     protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
-        codegenModel.additionalPropertiesType = getTypeDeclaration(ModelUtils.getAdditionalProperties(schema));
+        String addlType = getTypeDeclaration(ModelUtils.getAdditionalProperties(schema));
+        codegenModel.additionalPropertiesType = addlType;
         addImport(codegenModel, codegenModel.additionalPropertiesType);
+    }
+
+    @Override
+    /**
+     * Check the type to see if it needs import the library/module/package
+     *
+     * @param type name of the type
+     * @return true if the library/module/package of the corresponding type needs to be imported
+     */
+    protected boolean needToImport(String type) {
+        // Catch "advanced" primitives e.g. array or objects of primitives which should not be imported
+        if ( type.startsWith("{ [key:") || type.startsWith("[key:") || type.startsWith("Array<") ) {
+            return false;
+        }
+        return super.needToImport(type);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -589,6 +589,9 @@ public class ModelUtils {
      * @return true if it's any type
      */
     public static boolean isAnyType(Schema schema) {
+        if (schema == null) {
+            return false;
+        }
         if (StringUtils.isNotEmpty(schema.get$ref())) {
             // schemas with $ref: are not anyType, though their referenced schema may be
             return false;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -548,6 +548,16 @@ public class ModelUtils {
             return false;
         }
 
+        // not free-form if $ref to another schema, though $ref schema may be free-form
+        if (StringUtils.isNotEmpty(schema.get$ref())) {
+            return false;
+        }
+
+        // not free-form if enum
+        if (schema.getEnum() != null && !schema.getEnum().isEmpty()) {
+            return false;
+        }
+
         // not free-form if allOf, anyOf, oneOf is not empty
         if (schema instanceof ComposedSchema) {
             ComposedSchema cs = (ComposedSchema) schema;
@@ -579,6 +589,14 @@ public class ModelUtils {
      * @return true if it's any type
      */
     public static boolean isAnyType(Schema schema) {
+        if (StringUtils.isNotEmpty(schema.get$ref())) {
+            // schemas with $ref: are not anyType, though their referenced schema may be
+            return false;
+        }
+        if (schema.getEnum() != null && !schema.getEnum().isEmpty()) {
+            // enum schemas are not anyType
+            return false;
+        }
         if (schema instanceof ComposedSchema) {
             // Composed schemas (allOf, anyOf, oneOf) take the type(s) listed
             return false;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -168,7 +168,7 @@ public class GoModelTest {
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
-        Assert.assertEquals(property1.dataType, "interface{}");
+        Assert.assertEquals(property1.dataType, "Children");
         Assert.assertEquals(property1.name, "Children");
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
@@ -192,9 +192,9 @@ public class GoModelTest {
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
-        Assert.assertEquals(property1.dataType, "[]interface{}");
+        Assert.assertEquals(property1.dataType, "[]Children");
         Assert.assertEquals(property1.name, "Children");
-        Assert.assertEquals(property1.baseType, "[]interface{}");
+        Assert.assertEquals(property1.baseType, "[]Children");
         Assert.assertEquals(property1.containerType, "array");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
@@ -220,9 +220,9 @@ public class GoModelTest {
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
         Assert.assertEquals(property1.complexType, "Children");
-        Assert.assertEquals(property1.dataType, "map[string]interface{}");
+        Assert.assertEquals(property1.dataType, "map[string]Children");
         Assert.assertEquals(property1.name, "Children");
-        Assert.assertEquals(property1.baseType, "map[string]interface{}");
+        Assert.assertEquals(property1.baseType, "map[string]Children");
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
@@ -272,11 +272,11 @@ public class GoModelTest {
 
         final Schema model2 = new Schema().$ref("#/definitions/File");
         Assert.assertEquals(codegen.getSchemaType(model2), "File");
-        Assert.assertEquals(codegen.getTypeDeclaration(model2), "interface{}");
+        Assert.assertEquals(codegen.getTypeDeclaration(model2), "File");
 
         final Schema model3 = new Schema().$ref("#/components/schemas/File");
         Assert.assertEquals(codegen.getSchemaType(model3), "File");
-        Assert.assertEquals(codegen.getTypeDeclaration(model3), "interface{}");
+        Assert.assertEquals(codegen.getTypeDeclaration(model3), "File");
     }
 
     @DataProvider(name = "modelNames")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -144,7 +144,7 @@ public class GoModelTest {
         Assert.assertEquals(property1.baseName, "translations");
         Assert.assertEquals(property1.dataType, "map[string]string");
         Assert.assertEquals(property1.name, "Translations");
-        Assert.assertEquals(property1.baseType, "map");
+        Assert.assertEquals(property1.baseType, "map[string]string");
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -116,7 +116,7 @@ public class GoModelTest {
         Assert.assertEquals(property2.baseName, "urls");
         Assert.assertEquals(property2.dataType, "[]string");
         Assert.assertEquals(property2.name, "Urls");
-        Assert.assertEquals(property2.baseType, "array");
+        Assert.assertEquals(property2.baseType, "[]string");
         Assert.assertFalse(property2.hasMore);
         Assert.assertEquals(property2.containerType, "array");
         Assert.assertFalse(property2.required);
@@ -168,7 +168,7 @@ public class GoModelTest {
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
-        Assert.assertEquals(property1.dataType, "Children");
+        Assert.assertEquals(property1.dataType, "interface{}");
         Assert.assertEquals(property1.name, "Children");
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
@@ -192,9 +192,9 @@ public class GoModelTest {
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
-        Assert.assertEquals(property1.dataType, "[]Children");
+        Assert.assertEquals(property1.dataType, "[]interface{}");
         Assert.assertEquals(property1.name, "Children");
-        Assert.assertEquals(property1.baseType, "array");
+        Assert.assertEquals(property1.baseType, "[]interface{}");
         Assert.assertEquals(property1.containerType, "array");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
@@ -220,9 +220,9 @@ public class GoModelTest {
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
         Assert.assertEquals(property1.complexType, "Children");
-        Assert.assertEquals(property1.dataType, "map[string]Children");
+        Assert.assertEquals(property1.dataType, "map[string]interface{}");
         Assert.assertEquals(property1.name, "Children");
-        Assert.assertEquals(property1.baseType, "map");
+        Assert.assertEquals(property1.baseType, "map[string]interface{}");
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
@@ -272,11 +272,11 @@ public class GoModelTest {
 
         final Schema model2 = new Schema().$ref("#/definitions/File");
         Assert.assertEquals(codegen.getSchemaType(model2), "File");
-        Assert.assertEquals(codegen.getTypeDeclaration(model2), "File");
+        Assert.assertEquals(codegen.getTypeDeclaration(model2), "interface{}");
 
         final Schema model3 = new Schema().$ref("#/components/schemas/File");
         Assert.assertEquals(codegen.getSchemaType(model3), "File");
-        Assert.assertEquals(codegen.getTypeDeclaration(model3), "File");
+        Assert.assertEquals(codegen.getTypeDeclaration(model3), "interface{}");
     }
 
     @DataProvider(name = "modelNames")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -134,7 +134,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property2.baseName, "urls");
         Assert.assertEquals(property2.dataType, "Array<string>");
         Assert.assertEquals(property2.name, "urls");
-        Assert.assertEquals(property2.baseType, "Array");
+        Assert.assertEquals(property2.baseType, "Array<string>");
         Assert.assertFalse(property2.hasMore);
         Assert.assertFalse(property2.required);
     }
@@ -184,7 +184,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property1.complexType, "Children");
         Assert.assertEquals(property1.dataType, "Array<Children>");
         Assert.assertEquals(property1.name, "children");
-        Assert.assertEquals(property1.baseType, "Array");
+        Assert.assertEquals(property1.baseType, "Array<Children>");
         Assert.assertFalse(property1.required);
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -206,9 +206,22 @@ public class ModelUtilsTest {
         ObjectSchema objSchema = new ObjectSchema();
         Assert.assertTrue(ModelUtils.isFreeFormObject(objSchema));
 
+        // Create object schema with additionalProperties: true
+        ObjectSchema objSchemaAdlPropsTrue = new ObjectSchema();
+        objSchemaAdlPropsTrue.setAdditionalProperties(true);
+        Assert.assertTrue(ModelUtils.isFreeFormObject(objSchemaAdlPropsTrue));
+
+        // Create object schema with additionalProperties: {}
+        ObjectSchema objSchemaAdlPropsBlank = new ObjectSchema();
+        objSchemaAdlPropsBlank.setAdditionalProperties(new Schema());
+        Assert.assertTrue(ModelUtils.isFreeFormObject(objSchemaAdlPropsBlank));
+
         // Set additionalProperties to an empty ObjectSchema.
+        // This is actually a map of maps which is more restrictive than a free form object
+        // e.g. {"foo": {"bar": 1}} would be a valid map of maps
+        // however {"foo": 10} (which is a free form object) would NOT match this schema
         objSchema.setAdditionalProperties(new ObjectSchema());
-        Assert.assertTrue(ModelUtils.isFreeFormObject(objSchema));
+        Assert.assertFalse(ModelUtils.isFreeFormObject(objSchema));
 
         // Add a single property to the schema (no longer a free-form object).
         Map<String, Schema> props = new HashMap<>();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -235,4 +235,32 @@ public class ModelUtilsTest {
         // Test a null schema
         Assert.assertFalse(ModelUtils.isFreeFormObject(null));
     }
+
+    @Test
+    public void testIsAnyType() {
+        // Create empty schema equivalent to {}
+        Schema blankSchema = new Schema();
+        Assert.assertTrue(ModelUtils.isAnyType(blankSchema));
+
+        // Create schema with some trivial fields, still any type
+        Schema simpleSchema = new Schema();
+        simpleSchema.setTitle("myTitle");
+        Assert.assertTrue(ModelUtils.isAnyType(blankSchema));
+
+        // Create initial "empty" object schema, this is a map not any type
+        ObjectSchema objSchema = new ObjectSchema();
+        Assert.assertFalse(ModelUtils.isAnyType(objSchema));
+
+        // Add a single property to the schema
+        Map<String, Schema> props = new HashMap<>();
+        props.put("prop1", new StringSchema());
+        objSchema.setProperties(props);
+        Assert.assertFalse(ModelUtils.isAnyType(objSchema));
+
+        // Test a non-object schema
+        Assert.assertFalse(ModelUtils.isAnyType(new StringSchema()));
+
+        // Test a null schema
+        Assert.assertFalse(ModelUtils.isAnyType(null));
+    }
 }


### PR DESCRIPTION
Sample input:
```yaml
openapi: 3.0.0
info:
  description: My API Template
  title: Fake Service
  version: 0.0.1
servers:
  - http://fake.com
paths:
  /getme:
    get:
      tags:
      - v1
      operationId: getMe
      responses:
        "200":
          description: Success
          content:
            application/json:
              schema:
                type: object
                title: TestProperties
                properties:
                  myobj:
                    $ref: "#/components/schemas/MyObject"
                  myobjAddltrue:
                    $ref: "#/components/schemas/MyObjectAdditionalPropsTrue"
                  myobjAddlblank:
                    $ref: "#/components/schemas/MyObjectAdditionalPropsBlank"
                  myobjAllobj:
                    $ref: "#/components/schemas/MyObjectAdditionalPropsTypeObject"
                  mymapmodel:
                    $ref: "#/components/schemas/MyMapModel"
                  myany:
                    $ref: "#/components/schemas/MyAnyValue"
                  myanyDesc:
                    $ref: "#/components/schemas/MyAnyValueWithDescription"

components:
  schemas:
    # The following three are equivalent free-form objects with keys=strings and values=anyType
    # See: https://swagger.io/docs/specification/data-models/data-types/#free-form
    # e.g. {"foo": {"one": 1}, "bar": "two", "baz": [3, 4, 5]}
    MyObject:
      type: object
      # Note that additionalProperties is true by default,
      # see https://json-schema.org/understanding-json-schema/reference/object.html#properties
      description: I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
    MyObjectAdditionalPropsTrue:
      type: object
      additionalProperties: true
      description: I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
    MyObjectAdditionalPropsBlank:
      type: object
      additionalProperties: {}
      description: I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
    # This schema is a map of maps with keys=strings and values=free-form objects
    # e.g. {"foo":{"one": 1}, "bar": {"two": "dos"}, "baz": {"three": [3.3, 3.333]}}
    # but NOT {"bar": "two"} or {"baz": [3, 4, 5]}
    MyObjectAdditionalPropsTypeObject:
      type: object
      additionalProperties:
        type: object
      description: I am a map of maps with keys=strings and values=(free-form objects with keys=strings and values=any type)
    # This is map with specific properties (traditional model/struct)
    MyMapModel:
      type: object
      properties:
        freeFormProp:
          type: object
        intProp:
          type: integer
        strProp:
          type: string
      description: I am a map with three defined properties, a more traditional struct model - not a primitive type
    # The following two are equivalent and can be any type (string, array, integer, object, etc)
    # See https://swagger.io/docs/specification/data-models/data-types/#any
    # and https://cswr.github.io/JsonSchema/spec/multiple_types/
    # e.g. "foo" or ["foo", "bar"] or 23 or {"foo": "bar"}
    MyAnyValue: {}
    MyAnyValueWithDescription:
      description: This schema can be anything, see https://swagger.io/docs/specification/data-models/data-types/#any
```

Sample output (go):
```go
/*
 * Fake Service
 *
 * My API Template
 *
 * API version: 0.0.1
 * Generated by: OpenAPI Generator (https://openapi-generator.tech); DO NOT EDIT.
 */

package anyType

type MyAnyValue interface{}

// This schema can be anything, see https://swagger.io/docs/specification/data-models/data-types/#any
type MyAnyValueWithDescription interface{}

// I am a map with three defined properties, a more traditional struct model - not a primitive type
type MyMapModel struct {
	FreeFormProp *map[string]interface{} `json:"freeFormProp,omitempty"`
	IntProp      *int32                  `json:"intProp,omitempty"`
	StrProp      *string                 `json:"strProp,omitempty"`
}

// I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
type MyObject map[string]interface{}

// I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
type MyObjectAdditionalPropsBlank map[string]interface{}

// I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
type MyObjectAdditionalPropsTrue map[string]interface{}

// I am a map of maps with keys=strings and values=(free-form objects with keys=strings and values=any type)
type MyObjectAdditionalPropsTypeObject map[string]map[string]interface{}

type TestProperties struct {
	// I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
	Myobj          *map[string]interface{}            `json:"myobj,omitempty"`
	MyobjAddltrue  *MyObjectAdditionalPropsTrue       `json:"myobjAddltrue,omitempty"`
	MyobjAddlblank *MyObjectAdditionalPropsBlank      `json:"myobjAddlblank,omitempty"`
	MyobjAllobj    *MyObjectAdditionalPropsTypeObject `json:"myobjAllobj,omitempty"`
	Mymapmodel     *MyMapModel                        `json:"mymapmodel,omitempty"`
	Myany          *interface{}                       `json:"myany,omitempty"`
	// This schema can be anything, see https://swagger.io/docs/specification/data-models/data-types/#any
	MyanyDesc *interface{} `json:"myanyDesc,omitempty"`
}
```

Sample output (typescript-fetch):
```typescript
// tslint:disable
/**
 * Fake Service
 * My API Template
 *
 * OpenAPI spec version: 0.0.1
 * 
 *
 * NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech).
 * https://openapi-generator.tech
 * Do not edit the class manually.
 */

import {
    MyMapModel,
    MyObjectAdditionalPropsBlank,
    MyObjectAdditionalPropsTrue,
    MyObjectAdditionalPropsTypeObject,
} from './';

/**
 * 
 * @export
 * @interface TestProperties
 */
export interface TestProperties {
    /**
     * I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
     * @type {{ [key: string]: any; }}
     * @memberof TestProperties
     */
    myobj?: { [key: string]: any; };
    /**
     * 
     * @type {MyObjectAdditionalPropsTrue}
     * @memberof TestProperties
     */
    myobjAddltrue?: MyObjectAdditionalPropsTrue;
    /**
     * 
     * @type {MyObjectAdditionalPropsBlank}
     * @memberof TestProperties
     */
    myobjAddlblank?: MyObjectAdditionalPropsBlank;
    /**
     * 
     * @type {MyObjectAdditionalPropsTypeObject}
     * @memberof TestProperties
     */
    myobjAllobj?: MyObjectAdditionalPropsTypeObject;
    /**
     * 
     * @type {MyMapModel}
     * @memberof TestProperties
     */
    mymapmodel?: MyMapModel;
    /**
     * 
     * @type {any}
     * @memberof TestProperties
     */
    myany?: any;
    /**
     * This schema can be anything, see https://swagger.io/docs/specification/data-models/data-types/#any
     * @type {any}
     * @memberof TestProperties
     */
    myanyDesc?: any;
}

/**
 * I am a map of maps with keys=strings and values=(free-form objects with keys=strings and values=any type)
 * @export
 * @interface MyObjectAdditionalPropsTypeObject
 */
export interface MyObjectAdditionalPropsTypeObject {
    [key: string]: { [key: string]: any; };
}

/**
 * I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
 * @export
 * @interface MyObjectAdditionalPropsTrue
 */
export interface MyObjectAdditionalPropsTrue {
    [key: string]: any;
}

/**
 * I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
 * @export
 * @interface MyObjectAdditionalPropsBlank
 */
export interface MyObjectAdditionalPropsBlank {
    [key: string]: any;
}

/**
 * I am a free-from object with keys=strings and values=any type, see https://swagger.io/docs/specification/data-models/data-types/#free-form
 * @export
 * @interface MyObject
 */
export interface MyObject {
    [key: string]: any;
}

/**
 * I am a map with three defined properties, a more traditional struct model - not a primitive type
 * @export
 * @interface MyMapModel
 */
export interface MyMapModel {
    /**
     * 
     * @type {{ [key: string]: any; }}
     * @memberof MyMapModel
     */
    freeFormProp?: { [key: string]: any; };
    /**
     * 
     * @type {number}
     * @memberof MyMapModel
     */
    intProp?: number;
    /**
     * 
     * @type {string}
     * @memberof MyMapModel
     */
    strProp?: string;
}

/**
 * This schema can be anything, see https://swagger.io/docs/specification/data-models/data-types/#any
 * @export
 * @interface MyAnyValueWithDescription
 */
export interface MyAnyValueWithDescription {
    any;
}


/**
 * 
 * @export
 * @interface MyAnyValue
 */
export interface MyAnyValue {
    any;
}
```