### PR TITLE
Fix discriminator implicit mapping and add getPropertyBaseName

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
@@ -8,7 +8,8 @@ import java.util.Objects;
 import java.util.Set;
 
 public class CodegenDiscriminator {
-    private String propertyName;
+    private String propertyName; // propertyName: <value> converted to var name casing/
+    private String propertyBaseName; // original propertyName: <value>
     private Map<String, String> mapping;
     private Set<MappedModel> mappedModels = new LinkedHashSet<>();
 
@@ -18,6 +19,14 @@ public class CodegenDiscriminator {
 
     public void setPropertyName(String propertyName) {
         this.propertyName = propertyName;
+    }
+
+    public String getPropertyBaseName() {
+        return propertyBaseName;
+    }
+
+    public void setPropertyBaseName(String propertyBaseName) {
+        this.propertyBaseName = propertyBaseName;
     }
 
     public Map<String, String> getMapping() {
@@ -82,6 +91,7 @@ public class CodegenDiscriminator {
         if (o == null || getClass() != o.getClass()) return false;
         CodegenDiscriminator that = (CodegenDiscriminator) o;
         return Objects.equals(propertyName, that.propertyName) &&
+            Objects.equals(propertyBaseName, that.propertyBaseName) &&
             Objects.equals(mapping, that.mapping) &&
             Objects.equals(mappedModels, that.mappedModels);
     }
@@ -95,6 +105,7 @@ public class CodegenDiscriminator {
     public String toString() {
         return new ToStringBuilder(this)
                 .append("propertyName", propertyName)
+                .append("propertyBaseName", propertyBaseName)
                 .append("mapping", mapping)
                 .append("mappedModels", mappedModels)
                 .toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1831,6 +1831,7 @@ public class DefaultCodegen implements CodegenConfig {
         }
         CodegenDiscriminator discriminator = new CodegenDiscriminator();
         discriminator.setPropertyName(toVarName(schema.getDiscriminator().getPropertyName()));
+        discriminator.setPropertyBaseName(schema.getDiscriminator().getPropertyName());
         discriminator.setMapping(schema.getDiscriminator().getMapping());
         if (schema.getDiscriminator().getMapping() != null && !schema.getDiscriminator().getMapping().isEmpty()) {
             for (Entry<String, String> e : schema.getDiscriminator().getMapping().entrySet()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1838,19 +1838,23 @@ public class DefaultCodegen implements CodegenConfig {
                 String name = toModelName(ModelUtils.getSimpleRef(e.getValue())); // e.g e.getValue => #/components/schemas/Dog
                 discriminator.getMappedModels().add(new MappedModel(e.getKey(), name));
             }
-        } else {
-            Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
-            allDefinitions.forEach((childName, child) -> {
-                if (child instanceof ComposedSchema && ((ComposedSchema) child).getAllOf() != null) {
-                    Set<String> parentSchemas = ((ComposedSchema) child).getAllOf().stream()
-                            .filter(s -> s.get$ref() != null)
-                            .map(s -> ModelUtils.getSimpleRef(s.get$ref()))
-                            .collect(Collectors.toSet());
-                    if (parentSchemas.contains(schemaName)) {
-                        discriminator.getMappedModels().add(new MappedModel(childName, toModelName(childName)));
-                    }
+        } else if (schema instanceof ComposedSchema) {
+            ComposedSchema cs = (ComposedSchema) schema;
+            List<Schema> subschemas = new ArrayList<Schema>();
+            if (cs.getAllOf() != null) {
+                subschemas = cs.getAllOf();
+            } else if (cs.getAnyOf() != null) {
+                subschemas = cs.getAnyOf();
+            } else if (cs.getOneOf() != null) {
+                subschemas = cs.getOneOf();
+            }
+            for (Schema subschema : subschemas) {
+                if (subschema.get$ref() == null) {
+                    continue;
                 }
-            });
+                String subschemaName = ModelUtils.getSimpleRef(subschema.get$ref());
+                discriminator.getMappedModels().add(new MappedModel(subschemaName, toModelName(subschemaName)));
+            }
         }
         return discriminator;
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -436,6 +436,7 @@ public class DefaultCodegenTest {
         CodegenDiscriminator discriminator = animalModel.getDiscriminator();
         CodegenDiscriminator test = new CodegenDiscriminator();
         test.setPropertyName("className");
+        test.setPropertyBaseName("className");
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("Dog", "Dog"));
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("Cat", "Cat"));
         Assert.assertEquals(discriminator, test);
@@ -450,11 +451,13 @@ public class DefaultCodegenTest {
         String path = "/person/display/{personId}";
         Operation operation = openAPI.getPaths().get(path).getGet();
         CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", operation, null);
+        codegenOperation.discriminator.setPropertyBaseName("dollarUnderscoretype");
         verifyPersonDiscriminator(codegenOperation.discriminator);
 
         Schema person = openAPI.getComponents().getSchemas().get("Person");
         codegen.setOpenAPI(openAPI);
         CodegenModel personModel = codegen.fromModel("Person", person);
+        personModel.discriminator.setPropertyBaseName("dollarUnderscoretype");
         verifyPersonDiscriminator(personModel.discriminator);
     }
 
@@ -573,6 +576,7 @@ public class DefaultCodegenTest {
     private void verifyPersonDiscriminator(CodegenDiscriminator discriminator) {
         CodegenDiscriminator test = new CodegenDiscriminator();
         test.setPropertyName("DollarUnderscoretype");
+        test.setPropertyBaseName("dollarUnderscoretype");
         test.setMapping(new HashMap<>());
         test.getMapping().put("a", "#/components/schemas/Adult");
         test.getMapping().put("c", "#/components/schemas/Child");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -437,8 +437,6 @@ public class DefaultCodegenTest {
         CodegenDiscriminator test = new CodegenDiscriminator();
         test.setPropertyName("className");
         test.setPropertyBaseName("className");
-        test.getMappedModels().add(new CodegenDiscriminator.MappedModel("Dog", "Dog"));
-        test.getMappedModels().add(new CodegenDiscriminator.MappedModel("Cat", "Cat"));
         Assert.assertEquals(discriminator, test);
     }
 


### PR DESCRIPTION
getPropertyBaseName was needed as the propertyName is already converted to variable name syntax but we would like the original baseName from the OpenAPI spec for JSON unmarshaling