### PR TITLE
Allow generator to capture explode and style parameter fields from openapi

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -31,6 +31,8 @@ public class CodegenParameter {
             collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName;
 
     public String example; // example value (x-example)
+    public boolean explode;
+    public String style;
     public String jsonSchema;
     public boolean isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary,
             isBoolean, isDate, isDateTime, isUuid, isEmail, isFreeFormObject;
@@ -138,6 +140,8 @@ public class CodegenParameter {
         output.defaultValue = this.defaultValue;
         output.example = this.example;
         output.isEnum = this.isEnum;
+        output.style = this.style;
+        output.explode = this.explode;
         if (this._enum != null) {
             output._enum = new ArrayList<String>(this._enum);
         }
@@ -208,6 +212,8 @@ public class CodegenParameter {
             Objects.equals(baseType, that.baseType) &&
             Objects.equals(defaultValue, that.defaultValue) &&
             Objects.equals(example, that.example) &&
+            Objects.equals(style, that.style) &&
+            Objects.equals(explode, that.explode) &&
             Objects.equals(jsonSchema, that.jsonSchema) &&
             Objects.equals(isString, that.isString) &&
             Objects.equals(isNumeric, that.isNumeric) &&
@@ -275,6 +281,8 @@ public class CodegenParameter {
             baseType,
             defaultValue,
             example,
+            explode,
+            style,
             jsonSchema,
             isString,
             isNumeric,
@@ -343,6 +351,8 @@ public class CodegenParameter {
                 ", defaultValue='" + defaultValue + '\'' +
                 ", enumName='" + enumName + '\'' +
                 ", example='" + example + '\'' +
+                ", explode='" + explode + '\'' +
+                ", style='" + style + '\'' +
                 ", jsonSchema='" + jsonSchema + '\'' +
                 ", isString=" + isString +
                 ", isNumeric=" + isNumeric +

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2908,6 +2908,8 @@ public class DefaultCodegen implements CodegenConfig {
         codegenParameter.baseName = parameter.getName();
         codegenParameter.description = escapeText(parameter.getDescription());
         codegenParameter.unescapedDescription = parameter.getDescription();
+        codegenParameter.explode = parameter.getExplode();
+        codegenParameter.style = (parameter.getStyle() == null ? null : parameter.getStyle().toString());
         if (parameter.getRequired() != null) {
             codegenParameter.required = parameter.getRequired();
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2908,8 +2908,12 @@ public class DefaultCodegen implements CodegenConfig {
         codegenParameter.baseName = parameter.getName();
         codegenParameter.description = escapeText(parameter.getDescription());
         codegenParameter.unescapedDescription = parameter.getDescription();
-        codegenParameter.explode = parameter.getExplode();
         codegenParameter.style = (parameter.getStyle() == null ? null : parameter.getStyle().toString());
+        codegenParameter.explode = (parameter.getExplode() == Boolean.TRUE);
+        if (parameter.getExplode() == null && codegenParameter.style != null && codegenParameter.style.toLowerCase(Locale.ROOT) == "form") {
+            // if explode not explicitly set, use default value of "true" for style: form
+            codegenParameter.explode = Boolean.TRUE;
+        }
         if (parameter.getRequired() != null) {
             codegenParameter.required = parameter.getRequired();
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2910,10 +2910,6 @@ public class DefaultCodegen implements CodegenConfig {
         codegenParameter.unescapedDescription = parameter.getDescription();
         codegenParameter.style = (parameter.getStyle() == null ? null : parameter.getStyle().toString());
         codegenParameter.explode = (parameter.getExplode() == Boolean.TRUE);
-        if (parameter.getExplode() == null && codegenParameter.style != null && codegenParameter.style.toLowerCase(Locale.ROOT) == "form") {
-            // if explode not explicitly set, use default value of "true" for style: form
-            codegenParameter.explode = Boolean.TRUE;
-        }
         if (parameter.getRequired() != null) {
             codegenParameter.required = parameter.getRequired();
         }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

